### PR TITLE
Variable prec

### DIFF
--- a/examples/poisson.cpp
+++ b/examples/poisson.cpp
@@ -55,20 +55,12 @@ int main(int argc, char **argv) {
     mrcpp::print::memory(0, "used memory post project");
     t1.stop();
 
-    auto p_func = [](const mrcpp::Coord<D> &r) -> double { return 1.0e+2; };
-
-    mrcpp::FunctionTree<D> p_tree(MRA);
-    mrcpp::project<D>(prec, p_tree, p_func);
-    std::vector<mrcpp::FunctionTree<D> *> p_trees;
-    p_trees.push_back(&p_tree);
-    mrcpp::print::memory(0, "used memory post project p_func");
     // Applying Poisson operator
     auto t2 = mrcpp::Timer();
     mrcpp::print::separator(0, ' ');
     mrcpp::print::memory(0, "used memory pre apply");
     mrcpp::FunctionTree<D> g_tree(MRA);
-    // mrcpp::apply(prec, g_tree, P, f_tree);
-    mrcpp::apply(1.0 * prec, g_tree, P, f_tree, p_trees, -1, true);
+    mrcpp::apply(prec, g_tree, P, f_tree);
     mrcpp::print::memory(0, "used memory post apply");
     t2.stop();
 

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -219,18 +219,9 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
     MWTree<D> &gTree = gNode.getMWTree();
     double gThrs = gTree.getSquareNorm();
     if (gThrs > 0.0) {
-        auto nTerms = (double)this->oper->size();
-        auto precNorm = (this->precTrees.size()) ? 0.0 : 1.0;
-        for (int i = 0; i < this->precTrees.size(); i++) {
-            auto &pNode = get_func(this->precTrees, i).getNode(node.getNodeIndex());
-            auto n = node.getScale();
-            if (pNode.getMaxSquareNorm() > 0.0) {
-                precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
-            } else {
-                precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
-            }
-        }
-        gThrs = this->prec / precNorm * std::sqrt(gThrs / nTerms);
+        auto nTerms = static_cast<double>(this->oper->size());
+        auto precFac = this->precFunc(gNode.getNodeIndex());
+        gThrs = this->prec * precFac * std::sqrt(gThrs / nTerms);
     }
 
     os.gThreshold = gThrs;

--- a/src/treebuilders/ConvolutionCalculator.cpp
+++ b/src/treebuilders/ConvolutionCalculator.cpp
@@ -220,10 +220,9 @@ template <int D> void ConvolutionCalculator<D>::calcNode(MWNode<D> &node) {
     double gThrs = gTree.getSquareNorm();
     if (gThrs > 0.0) {
         auto nTerms = (double)this->oper->size();
-        auto precNorm = 1.0;
-        if (this->precTrees.size() > 0) precNorm = 0.0; // initialize
+        auto precNorm = (this->precTrees.size()) ? 0.0 : 1.0;
         for (int i = 0; i < this->precTrees.size(); i++) {
-            auto &pNode = precTrees[i]->getNode(node.getNodeIndex());
+            auto &pNode = get_func(this->precTrees, i).getNode(node.getNodeIndex());
             auto n = node.getScale();
             if (pNode.getMaxSquareNorm() > 0.0) {
                 precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -40,20 +40,22 @@ public:
 
     MWNodeVector<D> *getInitialWorkVector(MWTree<D> &tree) const override;
 
-    void setPrecTree(FunctionTreeVector<D> &treevec) { this->precTrees = treevec; }
+    void setPrecFunction(const std::function<double(const NodeIndex<D> &idx)> &prec_func) {
+        this->precFunc = prec_func;
+    }
 
 private:
     int maxDepth;
     double prec;
     ConvolutionOperator<D> *oper;
     FunctionTree<D> *fTree;
-    FunctionTreeVector<D> precTrees;
     std::vector<Timer *> band_t;
     std::vector<Timer *> calc_t;
     std::vector<Timer *> norm_t;
 
     OperatorStatistics<D> operStat;
     std::vector<Eigen::MatrixXi *> bandSizes;
+    std::function<double(const NodeIndex<D> &idx)> precFunc = [](const NodeIndex<D> &idx) { return 1.0; };
 
     static const int nComp = (1 << D);
     static const int nComp2 = (1 << D) * (1 << D);

--- a/src/treebuilders/ConvolutionCalculator.h
+++ b/src/treebuilders/ConvolutionCalculator.h
@@ -27,6 +27,7 @@
 
 #include "TreeCalculator.h"
 #include "operators/OperatorStatistics.h"
+#include "trees/FunctionTreeVector.h"
 
 #include "MRCPP/mrcpp_declarations.h"
 
@@ -39,14 +40,14 @@ public:
 
     MWNodeVector<D> *getInitialWorkVector(MWTree<D> &tree) const override;
 
-    void setPrecTree(std::vector<FunctionTree<D> *> treevec) { this->precTrees = treevec; }
+    void setPrecTree(FunctionTreeVector<D> &treevec) { this->precTrees = treevec; }
 
 private:
     int maxDepth;
     double prec;
     ConvolutionOperator<D> *oper;
     FunctionTree<D> *fTree;
-    std::vector<FunctionTree<D> *> precTrees;
+    FunctionTreeVector<D> precTrees;
     std::vector<Timer *> band_t;
     std::vector<Timer *> calc_t;
     std::vector<Timer *> norm_t;

--- a/src/treebuilders/MultiplicationAdaptor.h
+++ b/src/treebuilders/MultiplicationAdaptor.h
@@ -1,0 +1,76 @@
+/*
+ * MRCPP, a numerical library based on multiresolution analysis and
+ * the multiwavelet basis which provide low-scaling algorithms as well as
+ * rigorous error control in numerical computations.
+ * Copyright (C) 2020 Stig Rune Jensen, Jonas Juselius, Luca Frediani and contributors.
+ *
+ * This file is part of MRCPP.
+ *
+ * MRCPP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRCPP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRCPP.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRCPP, see:
+ * <https://mrcpp.readthedocs.io/>
+ */
+
+#pragma once
+
+#include "TreeAdaptor.h"
+#include "trees/FunctionTreeVector.h"
+#include "utils/Printer.h"
+
+namespace mrcpp {
+
+template <int D> class MultiplicationAdaptor : public TreeAdaptor<D> {
+public:
+    MultiplicationAdaptor(double pr, int ms, FunctionTreeVector<D> &t)
+            : TreeAdaptor<D>(ms)
+            , prec(pr)
+            , trees(t) {}
+    ~MultiplicationAdaptor() override = default;
+
+protected:
+    double prec;
+    mutable FunctionTreeVector<D> trees;
+
+    bool splitNode(const MWNode<D> &node) const override {
+        if (this->trees.size() != 2) MSG_ERROR("Invalid tree vec size: " << this->trees.size());
+        auto multPrec = 1.0;
+        auto &pNode0 = get_func(trees, 0).getNode(node.getNodeIndex());
+        auto &pNode1 = get_func(trees, 1).getNode(node.getNodeIndex());
+        double maxW0 = std::sqrt(pNode0.getMaxWSquareNorm());
+        double maxW1 = std::sqrt(pNode1.getMaxWSquareNorm());
+        double maxS0 = std::sqrt(pNode0.getMaxSquareNorm());
+        double maxS1 = std::sqrt(pNode1.getMaxSquareNorm());
+        if (pNode0.isGenNode()) {
+            maxW0 = 0.0;
+            maxS0 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode0.getSquareNorm());
+        }
+        if (pNode1.isGenNode()) {
+            maxW1 = 0.0;
+            maxS1 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode1.getSquareNorm());
+        }
+        // The wavelet contribution (in the product of node0 and node1) can be approximated as
+        multPrec = maxW0 * maxS1 + maxW1 * maxS0 + maxW0 * maxW1;
+
+        // Note: this never refine deeper than one scale more than input tree grids, because when wavelets are zero
+        // for both input trees, multPrec=0 In addition, we force not to refine deeper than input tree grids
+        if (multPrec > this->prec and not(pNode0.isLeafNode() and pNode1.isLeafNode())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+};
+
+} // namespace mrcpp

--- a/src/treebuilders/MultiplicationAdaptor.h
+++ b/src/treebuilders/MultiplicationAdaptor.h
@@ -45,27 +45,19 @@ protected:
 
     bool splitNode(const MWNode<D> &node) const override {
         if (this->trees.size() != 2) MSG_ERROR("Invalid tree vec size: " << this->trees.size());
-        auto multPrec = 1.0;
         auto &pNode0 = get_func(trees, 0).getNode(node.getNodeIndex());
         auto &pNode1 = get_func(trees, 1).getNode(node.getNodeIndex());
         double maxW0 = std::sqrt(pNode0.getMaxWSquareNorm());
         double maxW1 = std::sqrt(pNode1.getMaxWSquareNorm());
         double maxS0 = std::sqrt(pNode0.getMaxSquareNorm());
         double maxS1 = std::sqrt(pNode1.getMaxSquareNorm());
-        if (pNode0.isGenNode()) {
-            maxW0 = 0.0;
-            maxS0 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode0.getSquareNorm());
-        }
-        if (pNode1.isGenNode()) {
-            maxW1 = 0.0;
-            maxS1 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode1.getSquareNorm());
-        }
+
         // The wavelet contribution (in the product of node0 and node1) can be approximated as
-        multPrec = maxW0 * maxS1 + maxW1 * maxS0 + maxW0 * maxW1;
+        double multNorm = maxW0 * maxS1 + maxW1 * maxS0 + maxW0 * maxW1;
 
         // Note: this never refine deeper than one scale more than input tree grids, because when wavelets are zero
         // for both input trees, multPrec=0 In addition, we force not to refine deeper than input tree grids
-        if (multPrec > this->prec and not(pNode0.isLeafNode() and pNode1.isLeafNode())) {
+        if (multNorm > this->prec and not(pNode0.isLeafNode() and pNode1.isLeafNode())) {
             return true;
         } else {
             return false;

--- a/src/treebuilders/WaveletAdaptor.h
+++ b/src/treebuilders/WaveletAdaptor.h
@@ -39,58 +39,26 @@ public:
             , splitFac(sf) {}
     ~WaveletAdaptor() override = default;
 
-    void setPrecTree(std::vector<FunctionTree<D> *> treevec) { this->precTrees = treevec; }
-    void setMultiplicationSplit(bool multSplit) { this->multiplicationSplit = multSplit; };
+    void setPrecTree(FunctionTreeVector<D> &treevec) { this->precTrees = treevec; }
 
 protected:
     bool absPrec;
     double prec;
     double splitFac;
-    std::vector<FunctionTree<D> *> precTrees;
-    bool multiplicationSplit = false;
+    mutable FunctionTreeVector<D> precTrees;
 
     bool splitNode(const MWNode<D> &node) const override {
-        if (multiplicationSplit and this->precTrees.size() > 0) {
-            auto multPrec = 1.0;
-            if (this->precTrees.size() != 2) MSG_ERROR("Invalid precTree size: " << this->precTrees.size());
-            auto &pNode0 = precTrees[0]->getNode(node.getNodeIndex());
-            auto &pNode1 = precTrees[1]->getNode(node.getNodeIndex());
-            double maxW0 = std::sqrt(pNode0.getMaxWSquareNorm());
-            double maxW1 = std::sqrt(pNode1.getMaxWSquareNorm());
-            double maxS0 = std::sqrt(pNode0.getMaxSquareNorm());
-            double maxS1 = std::sqrt(pNode1.getMaxSquareNorm());
-            if (pNode0.isGenNode()) {
-                maxW0 = 0.0;
-                maxS0 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode0.getSquareNorm());
-            }
-            if (pNode1.isGenNode()) {
-                maxW1 = 0.0;
-                maxS1 = std::sqrt(std::pow(2.0, D * node.getScale()) * pNode1.getSquareNorm());
-            }
-            // The wavelet contribution (in the product of node0 and node1) can be approximated as
-            multPrec = maxW0 * maxS1 + maxW1 * maxS0 + maxW0 * maxW1;
-
-            // Note: this never refine deeper than one scale more than input tree grids, because when wavelets are zero
-            // for both input trees, multPrec=0 In addition, we force not to refine deeper than input tree grids
-            if (multPrec > this->prec and not(pNode0.isLeafNode() and pNode1.isLeafNode())) {
-                return true;
+        auto precNorm = (this->precTrees.size()) ? 0.0 : 1.0;
+        for (int i = 0; i < this->precTrees.size(); i++) {
+            auto &pNode = get_func(this->precTrees, i).getNode(node.getNodeIndex());
+            auto n = node.getScale();
+            if (not pNode.isGenNode() and pNode.getMaxSquareNorm() > 0.0) {
+                precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
             } else {
-                return false;
+                precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
             }
-        } else {
-            auto precNorm = 1.0;
-            if (this->precTrees.size() > 0) precNorm = 0.0; // initialize
-            for (int i = 0; i < this->precTrees.size(); i++) {
-                auto &pNode = precTrees[i]->getNode(node.getNodeIndex());
-                auto n = node.getScale();
-                if (not pNode.isGenNode() and pNode.getMaxSquareNorm() > 0.0) {
-                    precNorm = std::max(precNorm, std::sqrt(pNode.getMaxSquareNorm()));
-                } else {
-                    precNorm = std::max(precNorm, std::sqrt(std::pow(2.0, D * n) * pNode.getSquareNorm()));
-                }
-            }
-            return node.splitCheck(this->prec / precNorm, this->splitFac, this->absPrec);
         }
+        return node.splitCheck(this->prec / precNorm, this->splitFac, this->absPrec);
     }
 };
 

--- a/src/treebuilders/apply.cpp
+++ b/src/treebuilders/apply.cpp
@@ -99,15 +99,15 @@ void apply(double prec,
            FunctionTree<D> &out,
            ConvolutionOperator<D> &oper,
            FunctionTree<D> &inp,
-           std::vector<FunctionTree<D> *> precTrees,
+           FunctionTreeVector<D> &precTrees,
            int maxIter,
            bool absPrec) {
     Timer pre_t;
     oper.calcBandWidths(prec);
     int maxScale = out.getMRA().getMaxScale();
+    for (int i = 0; i < precTrees.size(); i++) get_func(precTrees, i).makeMaxSquareNorms();
     WaveletAdaptor<D> adaptor(prec, maxScale, absPrec);
     adaptor.setPrecTree(precTrees);
-    for (int i = 0; i < precTrees.size(); i++) { precTrees[i]->makeMaxSquareNorms(); }
     ConvolutionCalculator<D> calculator(prec, oper, inp);
     calculator.setPrecTree(precTrees);
     pre_t.stop();
@@ -257,21 +257,21 @@ template void apply(double prec,
                     FunctionTree<1> &out,
                     ConvolutionOperator<1> &oper,
                     FunctionTree<1> &inp,
-                    std::vector<FunctionTree<1> *> precTrees,
+                    FunctionTreeVector<1> &precTrees,
                     int maxIter,
                     bool absPrec);
 template void apply(double prec,
                     FunctionTree<2> &out,
                     ConvolutionOperator<2> &oper,
                     FunctionTree<2> &inp,
-                    std::vector<FunctionTree<2> *> precTrees,
+                    FunctionTreeVector<2> &precTrees,
                     int maxIter,
                     bool absPrec);
 template void apply(double prec,
                     FunctionTree<3> &out,
                     ConvolutionOperator<3> &oper,
                     FunctionTree<3> &inp,
-                    std::vector<FunctionTree<3> *> precTrees,
+                    FunctionTreeVector<3> &precTrees,
                     int maxIter,
                     bool absPrec);
 template void apply(FunctionTree<1> &out, DerivativeOperator<1> &oper, FunctionTree<1> &inp, int dir);

--- a/src/treebuilders/apply.h
+++ b/src/treebuilders/apply.h
@@ -35,7 +35,7 @@ template <int D> class DerivativeOperator;
 template <int D> class ConvolutionOperator;
 
 template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, int maxIter = -1, bool absPrec = false);
- template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, std::vector<FunctionTree<D> *> precTrees, int maxIter = -1, bool absPrec = false);
+template <int D> void apply(double prec, FunctionTree<D> &out, ConvolutionOperator<D> &oper, FunctionTree<D> &inp, FunctionTreeVector<D> &precTrees, int maxIter = -1, bool absPrec = false);
 template <int D> void apply(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTree<D> &inp, int dir = -1);
 template <int D> void divergence(FunctionTree<D> &out, DerivativeOperator<D> &oper, FunctionTreeVector<D> &inp);
 template <int D> FunctionTreeVector<D> gradient(DerivativeOperator<D> &oper, FunctionTree<D> &inp);

--- a/src/treebuilders/multiply.cpp
+++ b/src/treebuilders/multiply.cpp
@@ -54,6 +54,7 @@ namespace mrcpp {
  * @param[in] inp_b: Input function b
  * @param[in] maxIter: Maximum number of refinement iterations in output tree
  * @param[in] absPrec: Build output tree based on absolute precision
+ * @param[in] useMaxNorms: Build output tree based on norm estimates from input
  *
  * @details The output function will be computed as the product of the two input
  * functions (including the numerical coefficient), using the general algorithm:
@@ -90,6 +91,7 @@ void multiply(double prec,
  * @param[in] inp: Vector of input function
  * @param[in] maxIter: Maximum number of refinement iterations in output tree
  * @param[in] absPrec: Build output tree based on absolute precision
+ * @param[in] useMaxNorms: Build output tree based on norm estimates from input
  *
  * @details The output function will be computed as the product of all input
  * functions in the vector (including their numerical coefficients), using

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -1008,8 +1008,8 @@ template <int D> std::ostream &MWNode<D>::print(std::ostream &o) const {
  */
 template <int D> void MWNode<D>::setMaxSquareNorm() {
     auto n = this->getScale();
-    this->maxWSquareNorm = std::pow(2.0, D * n) * this->getWaveletNorm();
-    this->maxSquareNorm = std::pow(2.0, D * n) * this->getSquareNorm();
+    this->maxWSquareNorm = calcMaxWSquareNorm();
+    this->maxSquareNorm = calcMaxSquareNorm();
 
     if (not this->isEndNode()) {
         for (int i = 0; i < this->getTDim(); i++) {

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -71,6 +71,7 @@ MWNode<D>::MWNode(const MWNode<D> &node)
         , parent(nullptr)
         , squareNorm(-1.0)
         , maxSquareNorm(-1.0)
+        , maxWSquareNorm(-1.0)
         , coefs(nullptr)
         , n_coefs(0)
         , nodeIndex(node.nodeIndex)
@@ -1000,6 +1001,11 @@ template <int D> std::ostream &MWNode<D>::print(std::ostream &o) const {
     return o;
 }
 
+/** @brief recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
+ *
+ * @details normalization is such that a constant function gives constant value,
+ * i.e. *not* same normalization as a squareNorm
+ */
 template <int D> void MWNode<D>::setMaxSquareNorm() {
     auto n = this->getScale();
     this->maxWSquareNorm = std::pow(2.0, D * n) * this->getWaveletNorm();
@@ -1014,7 +1020,7 @@ template <int D> void MWNode<D>::setMaxSquareNorm() {
         }
     }
 }
-
+/** @brief recursively reset maxSquaredNorm and maxWSquareNorm of parent and descendants to value -1 */
 template <int D> void MWNode<D>::resetMaxSquareNorm() {
     auto n = this->getScale();
     this->maxSquareNorm = -1.0;

--- a/src/trees/MWNode.cpp
+++ b/src/trees/MWNode.cpp
@@ -1008,8 +1008,8 @@ template <int D> std::ostream &MWNode<D>::print(std::ostream &o) const {
  */
 template <int D> void MWNode<D>::setMaxSquareNorm() {
     auto n = this->getScale();
-    this->maxWSquareNorm = calcMaxWSquareNorm();
-    this->maxSquareNorm = calcMaxSquareNorm();
+    this->maxWSquareNorm = calcScaledWSquareNorm();
+    this->maxSquareNorm = calcScaledSquareNorm();
 
     if (not this->isEndNode()) {
         for (int i = 0; i < this->getTDim(); i++) {

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -82,9 +82,11 @@ public:
     inline bool isLooseNode() const;
 
     double getSquareNorm() const { return this->squareNorm; }
-    double getMaxSquareNorm() const { return (this->maxSquareNorm > 0.0) ? this->maxSquareNorm : calcMaxSquareNorm(); }
+    double getMaxSquareNorm() const {
+        return (this->maxSquareNorm > 0.0) ? this->maxSquareNorm : calcScaledSquareNorm();
+    }
     double getMaxWSquareNorm() const {
-        return (this->maxWSquareNorm > 0.0) ? this->maxWSquareNorm : calcMaxWSquareNorm();
+        return (this->maxWSquareNorm > 0.0) ? this->maxWSquareNorm : calcScaledWSquareNorm();
     }
 
     double getScalingNorm() const;
@@ -188,8 +190,8 @@ protected:
 
     void setMaxSquareNorm();
     void resetMaxSquareNorm();
-    double calcMaxSquareNorm() const { return std::pow(2.0, D * getScale()) * getSquareNorm(); }
-    double calcMaxWSquareNorm() const { return std::pow(2.0, D * getScale()) * getWaveletNorm(); }
+    double calcScaledSquareNorm() const { return std::pow(2.0, D * getScale()) * getSquareNorm(); }
+    double calcScaledWSquareNorm() const { return std::pow(2.0, D * getScale()) * getWaveletNorm(); }
     virtual double calcComponentNorm(int i) const;
 
     virtual void reCompress();

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -82,8 +82,11 @@ public:
     inline bool isLooseNode() const;
 
     double getSquareNorm() const { return this->squareNorm; }
-    double getMaxSquareNorm() const { return this->maxSquareNorm; }
-    double getMaxWSquareNorm() const { return this->maxWSquareNorm; }
+    double getMaxSquareNorm() const { return (this->maxSquareNorm > 0.0) ? this->maxSquareNorm : calcMaxSquareNorm(); }
+    double getMaxWSquareNorm() const {
+        return (this->maxWSquareNorm > 0.0) ? this->maxWSquareNorm : calcMaxWSquareNorm();
+    }
+
     double getScalingNorm() const;
     virtual double getWaveletNorm() const;
     double getComponentNorm(int i) const { return this->componentNorms[i]; }
@@ -185,6 +188,8 @@ protected:
 
     void setMaxSquareNorm();
     void resetMaxSquareNorm();
+    double calcMaxSquareNorm() const { return std::pow(2.0, D * getScale()) * getSquareNorm(); }
+    double calcMaxWSquareNorm() const { return std::pow(2.0, D * getScale()) * getWaveletNorm(); }
     virtual double calcComponentNorm(int i) const;
 
     virtual void reCompress();

--- a/src/trees/MWNode.h
+++ b/src/trees/MWNode.h
@@ -163,12 +163,6 @@ protected:
     double maxSquareNorm;          // Largest squared norm among itself and descendants.
     double maxWSquareNorm;         // Largest wavelet squared norm among itself and descendants.
                                    // NB: must be set before used.
-    // NB2: normalization is such that a constant function gives constant value, i.e. *not* same
-    // normalization as a squareNorm
-    void setMaxSquareNorm(); // recursively set maxSquaredNorm and maxWSquareNorm of parent and descendants
-    void
-    resetMaxSquareNorm(); // recursively reset maxSquaredNorm  and maxWSquareNorm of parent and descendants to value -1
-
     double *coefs;
     int n_coefs;
 
@@ -189,6 +183,8 @@ protected:
     virtual void allocCoefs(int n_blocks, int block_size);
     virtual void freeCoefs();
 
+    void setMaxSquareNorm();
+    void resetMaxSquareNorm();
     virtual double calcComponentNorm(int i) const;
 
     virtual void reCompress();


### PR DESCRIPTION
Changes made:

- `std::vector<FunctionTree *> -> FunctionTreeVector` for the `precTrees`.
- New `MultiplicationAdaptor` for the special case of the `WaveletAdaptor::splitNode`.
- New "precision function" which is used to scale the precision locally in `WaveletAdaptor` and `ConvolutionCalculator`. This function is defined in `apply()` and passed to both adaptor and calculator.
- `getMax(W)SquareNorm()` now always returns a non-negative number, if it is not precomputed with `makeMaxSquareNorms()` it will return the _scaled_ square norm (which also works for GenNodes). This removed a lot of logic after `getMaxSquareNorm()`. The behavior _should_ be unchanged for the current situations where `maxNorm` is used. :crossed_fingers: 